### PR TITLE
Add get_clipboard and set_clipboard to session.

### DIFF
--- a/frontend/code/rpc.ts
+++ b/frontend/code/rpc.ts
@@ -6,6 +6,8 @@ import {
     registerFont,
     closeSession,
     setTitle,
+    setClipboard,
+    getClipboard,
 } from './rpcFunctions';
 import { AsyncQueue, commitCss } from './utils';
 
@@ -365,6 +367,27 @@ export async function processMessageReturnResponse(
         case 'closeSession':
             closeSession();
             response = null;
+            break;
+
+        case 'setClipboard':
+            try {
+                await setClipboard(message.params.text);
+                response = null;
+            } catch (e) {
+                response = e.toString();
+                responseIsError = true;
+                console.warn(`Uncaught exception in \`setClipboard\`: ${e}`);
+            }
+            break;
+
+        case 'getClipboard':
+            try {
+                response = await getClipboard();
+            } catch (e) {
+                response = e.toString();
+                responseIsError = true;
+                console.warn(`Uncaught exception in \`getClipboard\`: ${e}`);
+            }
             break;
 
         default:

--- a/frontend/code/rpc.ts
+++ b/frontend/code/rpc.ts
@@ -8,6 +8,7 @@ import {
     setTitle,
     setClipboard,
     getClipboard,
+    ClipboardError,
 } from './rpcFunctions';
 import { AsyncQueue, commitCss } from './utils';
 
@@ -376,7 +377,13 @@ export async function processMessageReturnResponse(
             } catch (e) {
                 response = e.toString();
                 responseIsError = true;
-                console.warn(`Uncaught exception in \`setClipboard\`: ${e}`);
+                if (e instanceof ClipboardError) {
+                    console.warn(`ClipboardError: ${e.message}`);
+                } else {
+                    console.warn(
+                        `Uncaught exception in \`setClipboard\`: ${e}`
+                    );
+                }
             }
             break;
 
@@ -386,7 +393,13 @@ export async function processMessageReturnResponse(
             } catch (e) {
                 response = e.toString();
                 responseIsError = true;
-                console.warn(`Uncaught exception in \`getClipboard\`: ${e}`);
+                if (e instanceof ClipboardError) {
+                    console.warn(`ClipboardError: ${e.message}`);
+                } else {
+                    console.warn(
+                        `Uncaught exception in \`getClipboard\`: ${e}`
+                    );
+                }
             }
             break;
 

--- a/frontend/code/rpcFunctions.ts
+++ b/frontend/code/rpcFunctions.ts
@@ -132,3 +132,21 @@ export function setTitle(title: string): void {
 export function closeSession(): void {
     window.close(); // TODO: What if the browser doesn't allow this?
 }
+
+export async function setClipboard(text: string): Promise<void> {
+    try {
+        await navigator.clipboard.writeText(text);
+    } catch (error) {
+        console.warn(`Failed to set clipboard content: ${error}`);
+        throw new Error(`Failed to set clipboard content: ${error}`);
+    }
+}
+
+export async function getClipboard(): Promise<string> {
+    try {
+        return await navigator.clipboard.readText();
+    } catch (error) {
+        console.warn(`Failed to get clipboard content: ${error}`);
+        throw new Error(`Failed to get clipboard content: ${error}`);
+    }
+}

--- a/frontend/code/rpcFunctions.ts
+++ b/frontend/code/rpcFunctions.ts
@@ -133,20 +133,33 @@ export function closeSession(): void {
     window.close(); // TODO: What if the browser doesn't allow this?
 }
 
+export class ClipboardError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = this.constructor.name;
+    }
+}
+
 export async function setClipboard(text: string): Promise<void> {
+    if (!navigator.clipboard) {
+        throw new ClipboardError('Clipboard API is not available');
+    }
     try {
         await navigator.clipboard.writeText(text);
     } catch (error) {
         console.warn(`Failed to set clipboard content: ${error}`);
-        throw new Error(`Failed to set clipboard content: ${error}`);
+        throw new ClipboardError(`Failed to set clipboard content: ${error}`);
     }
 }
 
 export async function getClipboard(): Promise<string> {
+    if (!navigator.clipboard) {
+        throw new ClipboardError('Clipboard API is not available');
+    }
     try {
         return await navigator.clipboard.readText();
     } catch (error) {
         console.warn(`Failed to get clipboard content: ${error}`);
-        throw new Error(`Failed to get clipboard content: ${error}`);
+        throw new ClipboardError(`Failed to get clipboard content: ${error}`);
     }
 }

--- a/frontend/code/utils.ts
+++ b/frontend/code/utils.ts
@@ -122,6 +122,19 @@ export class TimeoutError extends Error {
 
 /// Copies the given text to the clipboard
 export function copyToClipboard(text: string): void {
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).catch((error) => {
+            console.warn(
+                `Failed to set clipboard content using navigator.clipboard: ${error}`
+            );
+            fallbackCopyToClipboard(text);
+        });
+    } else {
+        fallbackCopyToClipboard(text);
+    }
+}
+
+function fallbackCopyToClipboard(text: string): void {
     const textArea = document.createElement('textarea');
     textArea.value = text;
 

--- a/rio/session.py
+++ b/rio/session.py
@@ -67,6 +67,19 @@ class WontSerialize(Exception):
     pass
 
 
+class ClipboardError(Exception):
+    """
+    Exception raised for errors related to clipboard operations.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+    @property
+    def message(self) -> str:
+        return self.args[0]
+
+
 async def dummy_send_message(message: Jsonable) -> None:
     raise NotImplementedError()  # pragma: no cover
 
@@ -2476,7 +2489,10 @@ a.remove();
 
         `text`: The text to set on the clipboard.
         """
-        await self._remote_set_clipboard(text)
+        try:
+            await self._remote_set_clipboard(text)
+        except Exception as e:
+            raise ClipboardError(f"Failed to set clipboard content: {str(e)}")
 
     async def get_clipboard(self) -> str:
         """
@@ -2486,4 +2502,7 @@ a.remove();
 
         The text currently on the clipboard.
         """
-        return await self._remote_get_clipboard()
+        try:
+            return await self._remote_get_clipboard()
+        except Exception as e:
+            raise ClipboardError(f"Failed to get clipboard content: {str(e)}")

--- a/rio/session.py
+++ b/rio/session.py
@@ -2451,3 +2451,39 @@ a.remove();
                     self._call_event_handler(callback, component, refresh=True),
                     name="`on_on_window_size_change` event handler",
                 )
+
+    @unicall.remote(
+        name="setClipboard",
+        parameter_format="dict",
+        await_response=False,
+    )
+    async def _remote_set_clipboard(self, text: str) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    @unicall.remote(
+        name="getClipboard",
+        parameter_format="dict",
+        await_response=True,
+    )
+    async def _remote_get_clipboard(self) -> str:
+        raise NotImplementedError  # pragma: no cover
+
+    async def set_clipboard(self, text: str) -> None:
+        """
+        Set the client's clipboard to the given text.
+
+        ## Parameters
+
+        `text`: The text to set on the clipboard.
+        """
+        await self._remote_set_clipboard(text)
+
+    async def get_clipboard(self) -> str:
+        """
+        Get the current text from the client's clipboard.
+
+        ## Returns
+
+        The text currently on the clipboard.
+        """
+        return await self._remote_get_clipboard()


### PR DESCRIPTION
### What does it do?

This PR adds the ability to interact with the client's clipboard in the Rio framework. Specifically, it introduces two new methods:
- `set_clipboard` to set the clipboard text
- `get_clipboard` to retrieve the current clipboard text

### Why is it needed?

Clipboard operations enhance user experience by allowing easy copying and pasting of text programmatically.

### How to test it?

1. **Environment**: Ensure you have the development environment set up with the Rio framework.
2. **Path to Verify**:
    - Create buttons in your test app with `on_press` events.
    - Use `self.session.set_clipboard` and `self.session.get_clipboard` in these event handlers.
    - Click the buttons to test clipboard functionality.

### Related issue(s)/PR(s)

None