### PR TITLE
Replace string literals with ENUM types

### DIFF
--- a/rio/__init__.py
+++ b/rio/__init__.py
@@ -18,6 +18,7 @@ from .app import *
 from .color import *
 from .components import *
 from .cursor_style import *
+from .enums import *
 from .errors import *
 from .fills import *
 from .routing import *

--- a/rio/components/app_root.py
+++ b/rio/components/app_root.py
@@ -11,6 +11,8 @@ __all__ = [
     "AppRoot",
 ]
 
+from .. import ExpandStrategy
+
 
 class AppTopBar(component.Component):
     """
@@ -152,7 +154,7 @@ class AppRoot(component.Component):
                             0,
                             0,
                         ),
-                        height="grow",
+                        height=ExpandStrategy.GROW,
                     ),
                 ),
             ),

--- a/rio/components/banner.py
+++ b/rio/components/banner.py
@@ -11,6 +11,8 @@ __all__ = [
     "Banner",
 ]
 
+from .. import ExpandStrategy
+
 
 @final
 class Banner(component.Component):
@@ -115,12 +117,12 @@ class Banner(component.Component):
         if self.markdown:
             text_child = rio.Markdown(
                 text,
-                width="grow",
+                width=ExpandStrategy.GROW,
             )
         else:
             text_child = rio.Text(
                 text,
-                width="grow",
+                width=ExpandStrategy.GROW,
                 wrap=True,
                 justify="left",
             )

--- a/rio/components/button.py
+++ b/rio/components/button.py
@@ -14,6 +14,7 @@ __all__ = [
     "IconButton",
 ]
 
+from .. import ExpandStrategy
 
 CHILD_MARGIN_X = 1.0
 CHILD_MARGIN_Y = 0.3
@@ -185,7 +186,9 @@ class Button(Component):
             color=self.color,
             is_sensitive=self.is_sensitive,
             is_loading=self.is_loading,
-            width=8 if isinstance(self.content, str) else "natural",
+            width=8
+            if isinstance(self.content, str)
+            else ExpandStrategy.NATURAL,
             height=2.2,
         )
 
@@ -322,8 +325,8 @@ class IconButton(Component):
             margin_top=margin_top,
             margin_right=margin_right,
             margin_bottom=margin_bottom,
-            width="natural",
-            height="natural",
+            width=ExpandStrategy.NATURAL,
+            height=ExpandStrategy.NATURAL,
             align_x=align_x,
             align_y=align_y,
         )

--- a/rio/components/component.py
+++ b/rio/components/component.py
@@ -20,7 +20,7 @@ from uniserde import Jsonable, JsonDoc
 
 import rio
 
-from .. import deprecations, event, global_state, inspection
+from .. import ExpandStrategy, deprecations, event, global_state, inspection
 from ..dataclass import RioDataclassMeta, class_local_fields, internal_field
 from ..state_properties import AttributeBindingMaker, StateProperty
 
@@ -433,15 +433,14 @@ class Component(abc.ABC, metaclass=ComponentMeta):
         a margin of 1 is the height of a single line of text.
 
     `width`: How much horizontal space this component should request during
-        layouting. This can be either a number, or one of the special
-        values:
+        layouting. This can be either a number, or an expand strategy:
 
-        - If `"natural"`, the component will request the minimum amount it
+        - If `ExpandStrategy.NATURAL`, the component will request the minimum amount it
           requires to fit on the screen. For example a `Text` will request
           however much space the characters of that text require. A `Row`
           would request the sum of the widths of its children.
 
-        - If `"grow"`, the component will request all the remaining space in its parent.
+        - If `ExpandStrategy.GROW`, the component will request all the remaining space in its parent.
 
         - Please note that the space a `Component` receives during layouting
           may not match the request. As a general rule, for example, containers
@@ -453,14 +452,14 @@ class Component(abc.ABC, metaclass=ComponentMeta):
         the height of a single line of text.
 
     `height`: How much vertical space this component should request during
-        layouting. This can be either a number, or one of the special values:
+        layouting. This can be either a number, or an expand strategy:
 
-        - If `"natural"`, the component will request the minimum amount it
+        - If `ExpandStrategy.NATURAL`, the component will request the minimum amount it
           requires to fit on the screen. For example a `Text` will request
           however much space the characters of that text require. A `Row`
           would request the height of its tallest child.
 
-        - If `"grow"`, the component will request all the remaining space in its
+        - If `ExpandStrategy.GROW`, the component will request all the remaining space in its
           parent.
 
         - Please note that the space a `Component` receives during layouting
@@ -486,8 +485,8 @@ class Component(abc.ABC, metaclass=ComponentMeta):
     _: KW_ONLY
     key: str | None = internal_field(default=None, init=True)
 
-    width: float | Literal["natural", "grow"] = "natural"
-    height: float | Literal["natural", "grow"] = "natural"
+    width: float | ExpandStrategy = ExpandStrategy.NATURAL
+    height: float | ExpandStrategy = ExpandStrategy.NATURAL
 
     align_x: float | None = None
     align_y: float | None = None

--- a/rio/components/devel_component.py
+++ b/rio/components/devel_component.py
@@ -6,7 +6,6 @@ import tempfile
 from collections.abc import Iterable
 from dataclasses import field
 from pathlib import Path
-from typing import Literal
 
 import rio
 
@@ -15,6 +14,8 @@ from .fundamental_component import FundamentalComponent
 __all__ = [
     "DevelComponent",
 ]
+
+from .. import ExpandStrategy
 
 _SOURCE_DIRECTORY: Path | None = None
 
@@ -45,8 +46,8 @@ class DevelComponent(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/dropdown.py
+++ b/rio/components/dropdown.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import KW_ONLY, dataclass
-from typing import Any, Generic, Literal, TypeVar, final
+from typing import Any, Generic, TypeVar, final
 
 from uniserde import JsonDoc
 
@@ -14,6 +14,8 @@ __all__ = [
     "Dropdown",
     "DropdownChangeEvent",
 ]
+
+from .. import ExpandStrategy
 
 T = TypeVar("T")
 
@@ -147,8 +149,8 @@ class Dropdown(FundamentalComponent, Generic[T]):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/flow_container.py
+++ b/rio/components/flow_container.py
@@ -11,6 +11,8 @@ from .fundamental_component import FundamentalComponent
 
 __all__ = ["FlowContainer"]
 
+from .. import ExpandStrategy
+
 
 @final
 class FlowContainer(FundamentalComponent):
@@ -58,7 +60,9 @@ class FlowContainer(FundamentalComponent):
         *children: rio.Component,
         row_spacing: float = 0.0,
         column_spacing: float = 0.0,
-        justify: Literal["left", "center", "right", "justified", "grow"] = "center",
+        justify: Literal[
+            "left", "center", "right", "justified", "grow"
+        ] = "center",
         key: str | None = None,
         margin: float | None = None,
         margin_x: float | None = None,
@@ -67,8 +71,8 @@ class FlowContainer(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/grid.py
+++ b/rio/components/grid.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 from collections.abc import Iterable
 from dataclasses import KW_ONLY, dataclass
-from typing import Literal, final
+from typing import final
 
 from typing_extensions import Self
 from uniserde import JsonDoc
@@ -13,6 +13,8 @@ import rio
 from .fundamental_component import FundamentalComponent
 
 __all__ = ["Grid"]
+
+from .. import ExpandStrategy
 
 
 @final
@@ -113,8 +115,8 @@ class Grid(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):
@@ -140,7 +142,9 @@ class Grid(FundamentalComponent):
         # components and their positions separately
         self._children, self._child_positions = self._add_initial_children(rows)
 
-        self._properties_set_by_creator_.update(["_children", "_child_positions"])
+        self._properties_set_by_creator_.update(
+            ["_children", "_child_positions"]
+        )
 
     def _add_initial_children(
         self,
@@ -234,7 +238,9 @@ class Grid(FundamentalComponent):
             raise ValueError("Children have to take up at least one row")
 
         self._children.append(child)
-        self._child_positions.append(GridChildPosition(row, column, width, height))
+        self._child_positions.append(
+            GridChildPosition(row, column, width, height)
+        )
 
         # Return self for chaining
         return self

--- a/rio/components/icon.py
+++ b/rio/components/icon.py
@@ -6,7 +6,7 @@ from typing import Literal, final
 
 from uniserde import JsonDoc
 
-from .. import color, fills, icon_registry
+from .. import ExpandStrategy, color, fills, icon_registry
 from .fundamental_component import FundamentalComponent
 
 __all__ = [
@@ -195,8 +195,8 @@ class Icon(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["grow"] = 1.3,
-        height: float | Literal["grow"] = 1.3,
+        width: float | Literal[ExpandStrategy.GROW] = 1.3,
+        height: float | Literal[ExpandStrategy.GROW] = 1.3,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/labeled_column.py
+++ b/rio/components/labeled_column.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import field
-from typing import Literal, final
+from typing import final
 
 from typing_extensions import Self
 
@@ -11,6 +11,8 @@ import rio
 from .component import Component
 
 __all__ = ["LabeledColumn"]
+
+from .. import ExpandStrategy
 
 
 @final
@@ -57,8 +59,8 @@ class LabeledColumn(Component):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/linear_containers.py
+++ b/rio/components/linear_containers.py
@@ -15,6 +15,8 @@ __all__ = [
     "Column",
 ]
 
+from .. import ExpandStrategy
+
 
 class _LinearContainer(FundamentalComponent):
     children: list[rio.Component]
@@ -50,13 +52,13 @@ class Row(_LinearContainer):
 
     When a `Row` has more horizontal space available than it needs, it will
     evenly distribute the extra space among all child components whose `width`
-    is set to `"grow"`.
+    is set to `ExpandStrategy.GROW`.
 
-    If no child is set to `"grow"`, the extra space is evenly distributed among
+    If no child is set to `ExpandStrategy.GROW`, the extra space is evenly distributed among
     all children. This is why components in a `Row` can sometimes become
     unexpectedly large. If you don't want that to happen, you can either tell
     rio which children should receive the extra space by setting their `width`
-    to `"grow"`, or you can set the `Row`s `align_x` to something other than
+    to `ExpandStrategy.GROW`, or you can set the `Row`s `align_x` to something other than
     `None`, which will cause the `Row` to only take up as much space as
     necessary and position itself in the available space.
 
@@ -131,8 +133,8 @@ class Row(_LinearContainer):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):
@@ -193,13 +195,13 @@ class Column(_LinearContainer):
 
     When a `Column` has more vertical space available than it needs, it will
     evenly distribute the extra space among all child components whose `height`
-    is set to `"grow"`.
+    is set to `ExpandStrategy.GROW`.
 
-    If no child is set to `"grow"`, the extra space is evenly distributed among
+    If no child is set to `ExpandStrategy.GROW`, the extra space is evenly distributed among
     all children. This is why components in a `Column` can sometimes become
     unexpectedly large. If you don't want that to happen, you can either tell
     rio which children should receive the extra space by setting their `height`
-    to `"grow"`, or you can set the `Column`s `align_y` to something other than
+    to `ExpandStrategy.GROW`, or you can set the `Column`s `align_y` to something other than
     `None`, which will cause the `Column` to only take up as much space as
     necessary and position itself in the available space.
 
@@ -273,8 +275,8 @@ class Column(_LinearContainer):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/link.py
+++ b/rio/components/link.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, final
+from typing import final
 
 from uniserde import JsonDoc
 
@@ -11,6 +11,8 @@ from .fundamental_component import FundamentalComponent
 __all__ = [
     "Link",
 ]
+
+from .. import ExpandStrategy
 
 
 @final
@@ -66,8 +68,8 @@ class Link(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):
@@ -103,7 +105,9 @@ class Link(FundamentalComponent):
         self.target_url = target_url
         self.open_in_new_tab = open_in_new_tab
 
-        self._properties_set_by_creator_.update(("child_text", "child_component"))
+        self._properties_set_by_creator_.update(
+            ("child_text", "child_component")
+        )
 
     def _custom_serialize(self) -> JsonDoc:
         # Get the full URL to navigate to

--- a/rio/components/list_items.py
+++ b/rio/components/list_items.py
@@ -16,6 +16,8 @@ __all__ = [
     "CustomListItem",
 ]
 
+from .. import ExpandStrategy
+
 
 @final
 class HeadingListItem(FundamentalComponent):
@@ -177,8 +179,8 @@ class SimpleListItem(Component):
         left_child: rio.Component | None = None,
         right_child: rio.Component | None = None,
         on_press: rio.EventHandler[[]] = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
     ) -> None:
         super().__init__(
             width=width,
@@ -221,7 +223,7 @@ class SimpleListItem(Component):
             rio.Column(
                 *text_children,
                 spacing=0.5,
-                width="grow",
+                width=ExpandStrategy.GROW,
                 align_y=0.5,  # In case too much space is allocated
             )
         )
@@ -235,7 +237,7 @@ class SimpleListItem(Component):
             content=rio.Row(
                 *children,
                 spacing=1,
-                width="grow",
+                width=ExpandStrategy.GROW,
             ),
             on_press=self.on_press,
             key="",
@@ -331,8 +333,8 @@ class CustomListItem(FundamentalComponent):
         *,
         key: str | None = None,
         on_press: rio.EventHandler[[]] = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
     ) -> None:
         super().__init__(
             width=width,

--- a/rio/components/list_view.py
+++ b/rio/components/list_view.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, final
+from typing import final
 
 from typing_extensions import Self
 
@@ -9,6 +9,8 @@ import rio
 from .fundamental_component import FundamentalComponent
 
 __all__ = ["ListView"]
+
+from .. import ExpandStrategy
 
 
 @final
@@ -106,8 +108,8 @@ class ListView(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ) -> None:

--- a/rio/components/media_player.py
+++ b/rio/components/media_player.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import pathlib
-from typing import Literal, final
+from typing import final
 
 from uniserde import JsonDoc
 
 import rio
 
-from .. import assets, color, fills
+from .. import ExpandStrategy, assets, color, fills
 from ..utils import EventHandler
 from .fundamental_component import KeyboardFocusableFundamentalComponent
 
@@ -115,8 +115,8 @@ class MediaPlayer(KeyboardFocusableFundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/node_input.py
+++ b/rio/components/node_input.py
@@ -10,6 +10,8 @@ __all__ = [
     "NodeInput",
 ]
 
+from .. import ExpandStrategy
+
 
 @final
 class NodeInput(FundamentalComponent):
@@ -37,8 +39,8 @@ class NodeInput(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
     ):
         # Make sure the building component is a Node
         # TODO

--- a/rio/components/node_output.py
+++ b/rio/components/node_output.py
@@ -10,6 +10,8 @@ __all__ = [
     "NodeOutput",
 ]
 
+from .. import ExpandStrategy
+
 
 @final
 class NodeOutput(FundamentalComponent):
@@ -37,8 +39,8 @@ class NodeOutput(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
     ):
         # Make sure the building component is a Node
         # TODO

--- a/rio/components/page_view.py
+++ b/rio/components/page_view.py
@@ -78,7 +78,7 @@ class PageView(Component):
         build=lambda: rio.Column(
             rio.Text("Welcome to my page!"),
             rio.PageView(
-                height="grow",
+                height=ExpandStrategy.GROW,
             ),
         ),
         pages=[

--- a/rio/components/plot.py
+++ b/rio/components/plot.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import copy
 import io
-from typing import TYPE_CHECKING, Literal, cast, final
+from typing import TYPE_CHECKING, cast, final
 
 from uniserde import JsonDoc
 
-
-from .. import fills, maybes
+from .. import ExpandStrategy, fills, maybes
 from .fundamental_component import FundamentalComponent
 
 if TYPE_CHECKING:
@@ -92,8 +91,8 @@ class Plot(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: Literal["natural", "grow"] | float = "natural",
-        height: Literal["natural", "grow"] | float = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/progress_bar.py
+++ b/rio/components/progress_bar.py
@@ -10,6 +10,8 @@ __all__ = [
     "ProgressBar",
 ]
 
+from .. import ExpandStrategy
+
 
 @final
 class ProgressBar(FundamentalComponent):
@@ -70,8 +72,8 @@ class ProgressBar(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/progress_circle.py
+++ b/rio/components/progress_circle.py
@@ -10,6 +10,8 @@ __all__ = [
     "ProgressCircle",
 ]
 
+from .. import ExpandStrategy
+
 
 @final
 class ProgressCircle(FundamentalComponent):
@@ -63,7 +65,7 @@ class ProgressCircle(FundamentalComponent):
         progress: float | None = None,
         *,
         color: rio.ColorSet = "keep",
-        size: float | Literal["grow"] = 3.5,
+        size: float | Literal[ExpandStrategy.GROW] = 3.5,
         key: str | None = None,
         margin: float | None = None,
         margin_x: float | None = None,

--- a/rio/components/slider.py
+++ b/rio/components/slider.py
@@ -15,6 +15,8 @@ __all__ = [
     "SliderChangeEvent",
 ]
 
+from .. import ExpandStrategy
+
 
 @final
 @dataclass
@@ -115,8 +117,8 @@ class Slider(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["grow"] = 1.3,
-        height: float | Literal["grow"] = 1.3,
+        width: float | Literal[ExpandStrategy.GROW] = 1.3,
+        height: float | Literal[ExpandStrategy.GROW] = 1.3,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/slideshow.py
+++ b/rio/components/slideshow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import KW_ONLY
 from datetime import timedelta
-from typing import Literal, final
+from typing import final
 
 from uniserde import JsonDoc
 
@@ -13,6 +13,8 @@ from .fundamental_component import FundamentalComponent
 __all__ = [
     "Slideshow",
 ]
+
+from .. import ExpandStrategy
 
 
 @final
@@ -71,8 +73,8 @@ class Slideshow(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/spacer.py
+++ b/rio/components/spacer.py
@@ -8,6 +8,8 @@ __all__ = [
     "Spacer",
 ]
 
+from .. import ExpandStrategy
+
 
 @final
 class Spacer(class_container.ClassContainer):
@@ -40,8 +42,8 @@ class Spacer(class_container.ClassContainer):
     def __init__(
         self,
         *,
-        width: float | Literal["grow"] = "grow",
-        height: float | Literal["grow"] = "grow",
+        width: float | Literal[ExpandStrategy.GROW] = ExpandStrategy.GROW,
+        height: float | Literal[ExpandStrategy.GROW] = ExpandStrategy.GROW,
         key: str | None = None,
     ):
         """

--- a/rio/components/stack.py
+++ b/rio/components/stack.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, final
+from typing import final
 
 from typing_extensions import Self
 
@@ -9,6 +9,8 @@ import rio
 from .fundamental_component import FundamentalComponent
 
 __all__ = ["Stack"]
+
+from .. import ExpandStrategy
 
 
 @final
@@ -73,8 +75,8 @@ class Stack(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/switcher_bar.py
+++ b/rio/components/switcher_bar.py
@@ -8,7 +8,7 @@ from uniserde import JsonDoc
 
 import rio
 
-from .. import icon_registry
+from .. import ExpandStrategy, icon_registry
 from .fundamental_component import FundamentalComponent
 
 __all__ = [
@@ -110,7 +110,7 @@ class SwitcherBar(FundamentalComponent, Generic[T]):
                         on_change=self.on_change,
                     ),
                     margin=1,
-                    width="grow",
+                    width=ExpandStrategy.GROW,
                 ),
             )
     ```
@@ -150,8 +150,8 @@ class SwitcherBar(FundamentalComponent, Generic[T]):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/components/tooltip.py
+++ b/rio/components/tooltip.py
@@ -10,6 +10,8 @@ __all__ = [
     "Tooltip",
 ]
 
+from .. import ExpandStrategy
+
 
 @final
 class Tooltip(FundamentalComponent):
@@ -73,8 +75,8 @@ class Tooltip(FundamentalComponent):
         margin_top: float | None = None,
         margin_right: float | None = None,
         margin_bottom: float | None = None,
-        width: float | Literal["natural", "grow"] = "natural",
-        height: float | Literal["natural", "grow"] = "natural",
+        width: float | ExpandStrategy = ExpandStrategy.NATURAL,
+        height: float | ExpandStrategy = ExpandStrategy.NATURAL,
         align_x: float | None = None,
         align_y: float | None = None,
     ):

--- a/rio/debug/dev_tools/deploy_page.py
+++ b/rio/debug/dev_tools/deploy_page.py
@@ -1,4 +1,5 @@
 import rio
+from rio import ExpandStrategy
 
 
 class DeployPage(rio.Component):
@@ -21,7 +22,7 @@ class DeployPage(rio.Component):
                 rio.Text("One-click deployment is coming soon!"),
                 rio.Text("Stay tuned for updates."),
                 spacing=1,
-                height="grow",
+                height=ExpandStrategy.GROW,
                 align_y=0.3,
                 margin=1,
             ),

--- a/rio/debug/dev_tools/docs_page.py
+++ b/rio/debug/dev_tools/docs_page.py
@@ -1,4 +1,5 @@
 import rio
+from rio import ExpandStrategy
 
 
 class DocsPage(rio.Component):
@@ -23,7 +24,7 @@ class DocsPage(rio.Component):
                     on_press=self._open_tutorial,
                 ),
                 spacing=1,
-                height="grow",
+                height=ExpandStrategy.GROW,
                 align_y=0.5,
                 margin=1,
             ),

--- a/rio/debug/dev_tools/icons_page.py
+++ b/rio/debug/dev_tools/icons_page.py
@@ -9,6 +9,7 @@ import fuzzywuzzy.fuzz
 import rio
 import rio.icon_registry
 
+from ... import ExpandStrategy
 from . import sample_icons_grid
 
 T = TypeVar("T")
@@ -268,12 +269,14 @@ class IconsPage(rio.Component):
                                 self._on_select_variant, variant
                             ),
                         ),
-                        width="grow",
+                        width=ExpandStrategy.GROW,
                         align_y=0.5,
                     )
                 )
 
-            children.append(rio.Row(*variant_buttons, width="grow"))
+            children.append(
+                rio.Row(*variant_buttons, width=ExpandStrategy.GROW)
+            )
 
         # Which parameters should be passed?
         params_dict = {
@@ -376,7 +379,7 @@ Use the `rio.Icon` component like this:
                     row_spacing=0.5,
                     column_spacing=0.5,
                     justify="left",
-                    height="grow",
+                    height=ExpandStrategy.GROW,
                     align_y=0,
                 )
             )
@@ -385,7 +388,7 @@ Use the `rio.Icon` component like this:
         if not has_search:
             children.append(
                 sample_icons_grid.SampleIconsGrid(
-                    height="grow",
+                    height=ExpandStrategy.GROW,
                     margin_top=2,
                     on_select_icon=self._on_select_icon_by_name,
                 )
@@ -410,7 +413,7 @@ Use the `rio.Icon` component like this:
                         spacing=1,
                         align_y=0.5,
                     ),
-                    height="grow",
+                    height=ExpandStrategy.GROW,
                 )
             )
 

--- a/rio/debug/dev_tools/theme_picker_page.py
+++ b/rio/debug/dev_tools/theme_picker_page.py
@@ -3,6 +3,7 @@ import io
 from typing import *  # type: ignore
 
 import rio
+from rio import ExpandStrategy
 
 
 def colors_equal(color1: rio.Color, color2: rio.Color) -> bool:
@@ -358,7 +359,7 @@ class ThemePickerPage(rio.Component):
                     value=self.session.theme.corner_radius_small,
                     minimum=slider_min,
                     maximum=slider_max,
-                    width="grow",
+                    width=ExpandStrategy.GROW,
                     on_change=functools.partial(
                         self._on_radius_change,
                         "corner_radius_small",
@@ -374,7 +375,7 @@ class ThemePickerPage(rio.Component):
                     value=self.session.theme.corner_radius_medium,
                     minimum=slider_min,
                     maximum=slider_max,
-                    width="grow",
+                    width=ExpandStrategy.GROW,
                     on_change=functools.partial(
                         self._on_radius_change,
                         "corner_radius_medium",
@@ -390,7 +391,7 @@ class ThemePickerPage(rio.Component):
                     value=self.session.theme.corner_radius_large,
                     minimum=slider_min,
                     maximum=slider_max,
-                    width="grow",
+                    width=ExpandStrategy.GROW,
                     on_change=functools.partial(
                         self._on_radius_change,
                         "corner_radius_large",

--- a/rio/debug/dev_tools/tree_page.py
+++ b/rio/debug/dev_tools/tree_page.py
@@ -2,6 +2,7 @@ from typing import *  # type: ignore
 
 import rio.components.component_tree
 
+from ... import ExpandStrategy
 from . import component_details
 
 
@@ -28,9 +29,9 @@ class TreePage(rio.Component):
                     margin_left=margin,
                     on_select_component=self._on_select_component,
                 ),
-                height="grow",
+                height=ExpandStrategy.GROW,
             ),
-            height="grow",
+            height=ExpandStrategy.GROW,
         )
 
         if self._selected_component_id is not None:

--- a/rio/enums.py
+++ b/rio/enums.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class ExpandStrategy(Enum):
+    NATURAL = "natural"
+    GROW = "grow"

--- a/rio/routing.py
+++ b/rio/routing.py
@@ -34,7 +34,7 @@ class Page:
     app = rio.App(
         build=lambda: rio.Column(
             rio.Text("Welcome to my app!"),
-            rio.PageView(height="grow"),
+            rio.PageView(height=ExpandStrategy.GROW),
         ),
         pages=[
             rio.Page(

--- a/rio/serialization.py
+++ b/rio/serialization.py
@@ -13,7 +13,7 @@ from uniserde import Jsonable, JsonDoc
 
 import rio
 
-from . import color, fills, inspection, maybes, session
+from . import ExpandStrategy, color, fills, inspection, maybes, session
 from .components import fundamental_component
 from .dataclass import class_local_fields
 from .self_serializing import SelfSerializing
@@ -110,8 +110,8 @@ def serialize_and_host_component(component: rio.Component) -> JsonDoc:
         component.align_y,
     )
     result["_grow_"] = (
-        width == "grow",
-        height == "grow",
+        width == ExpandStrategy.GROW,
+        height == ExpandStrategy.GROW,
     )
 
     # If it's a fundamental component, serialize its state because JS needs it.

--- a/rio/snippets/snippet-files/project-template-AI Chatbot/components/chat_message.py
+++ b/rio/snippets/snippet-files/project-template-AI Chatbot/components/chat_message.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import *  # type: ignore
 
 import rio
+from rio import ExpandStrategy
 
 # <additional-imports>
 from .. import conversation
@@ -54,7 +55,7 @@ class ChatMessage(rio.Component):
                     self.model.text,
                     margin=1.5,
                 ),
-                width="grow",
+                width=ExpandStrategy.GROW,
                 color=color,
             ),
         )

--- a/rio/snippets/snippet-files/project-template-AI Chatbot/components/chat_suggestion_card.py
+++ b/rio/snippets/snippet-files/project-template-AI Chatbot/components/chat_suggestion_card.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import *  # type: ignore
 
 import rio
+from rio import ExpandStrategy
 
 
 # <component>
@@ -29,7 +30,7 @@ class ChatSuggestionCard(rio.Component):
                 rio.Text(
                     self.text,
                     wrap=True,
-                    height="grow",
+                    height=ExpandStrategy.GROW,
                     align_y=0.5,
                 ),
                 rio.Button(

--- a/rio/snippets/snippet-files/project-template-AI Chatbot/components/empty_chat_placeholder.py
+++ b/rio/snippets/snippet-files/project-template-AI Chatbot/components/empty_chat_placeholder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import *  # type: ignore
 
 import rio
+from rio import ExpandStrategy
 
 from .. import components as comps
 
@@ -63,7 +64,7 @@ class EmptyChatPlaceholder(rio.Component):
                     label="Ask something...",
                     text=self.bind().user_message_text,
                     on_confirm=self.on_text_input_confirm,
-                    width="grow",
+                    width=ExpandStrategy.GROW,
                     height=5,
                 ),
                 rio.IconButton(

--- a/rio/snippets/snippet-files/project-template-AI Chatbot/pages/chat_page.py
+++ b/rio/snippets/snippet-files/project-template-AI Chatbot/pages/chat_page.py
@@ -9,6 +9,7 @@ from typing import *  # type: ignore
 import openai
 
 import rio
+from rio import ExpandStrategy
 
 from .. import components as comps
 from .. import conversation
@@ -152,7 +153,7 @@ class ChatPage(rio.Component):
                     ),
                     scroll_x="never",
                     scroll_y="auto",
-                    height="grow",
+                    height=ExpandStrategy.GROW,
                 ),
                 # User input
                 rio.Row(
@@ -161,7 +162,7 @@ class ChatPage(rio.Component):
                         text=self.bind().user_message_text,
                         on_confirm=self.on_text_input_confirm,
                         is_sensitive=not self.is_loading,
-                        width="grow",
+                        width=ExpandStrategy.GROW,
                         height=8,
                     ),
                     rio.IconButton(

--- a/rio/snippets/snippet-files/project-template-Multipage Website/pages/root_page.py
+++ b/rio/snippets/snippet-files/project-template-Multipage Website/pages/root_page.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import *  # type: ignore
 
 import rio
+from rio import ExpandStrategy
 
 from .. import components as comps
 
@@ -32,7 +33,7 @@ class RootPage(rio.Component):
             # The page view will display the content of the current page.
             rio.PageView(
                 # Make sure the page view takes up all available space.
-                height="grow",
+                height=ExpandStrategy.GROW,
             ),
             # The footer is also common to all pages, so place it here.
             comps.Footer(),

--- a/rio/snippets/snippet-files/project-template-Todo App/components/new_todo_item_input.py
+++ b/rio/snippets/snippet-files/project-template-Todo App/components/new_todo_item_input.py
@@ -6,6 +6,7 @@ from dataclasses import field
 from typing import *  # type: ignore
 
 import rio
+from rio import ExpandStrategy
 
 from ..data_models import TodoItem
 
@@ -51,7 +52,7 @@ class NewTodoItemInput(rio.Component):
                 label="Enter a new todo item",
                 text=self.bind()._title,
                 on_confirm=self._on_confirm,
-                width="grow",
+                width=ExpandStrategy.GROW,
             ),
             rio.IconButton(
                 "material/add",

--- a/rio/snippets/snippet-files/project-template-Todo App/pages/todo_list_page.py
+++ b/rio/snippets/snippet-files/project-template-Todo App/pages/todo_list_page.py
@@ -5,6 +5,7 @@ import functools
 from typing import *  # type: ignore
 
 import rio
+from rio import ExpandStrategy
 
 from .. import components as comps
 from ..data_models import TodoAppSettings, TodoItem
@@ -76,7 +77,7 @@ class TodoListPage(rio.Component):
                     for todo_item in settings.todo_items
                 ],
                 rio.Spacer(),
-                height="grow",
+                height=ExpandStrategy.GROW,
             ),
             # Input for new todo items
             comps.NewTodoItemInput(

--- a/tests/test_zzz_guardrails.py
+++ b/tests/test_zzz_guardrails.py
@@ -5,6 +5,7 @@ import pytest
 from utils import enable_component_instantiation
 
 import rio.testing
+from rio import ExpandStrategy
 from rio.debug.monkeypatches import apply_monkeypatches
 
 apply_monkeypatches()
@@ -22,7 +23,7 @@ def test_type_checking():
         key="key",
         wrap=True,
         margin_x=2,
-        width="grow",
+        width=ExpandStrategy.GROW,
     )
     rio.Container(rio.Text("bar"))
 


### PR DESCRIPTION
_DO NOT MERGE YET - NOT FINAL_

### What does it do?

This pull request replaces the existing Literal string type annotations with an Enum type. This change is aimed at improving the maintainability, readability, and robustness of the codebase.

### Why is it needed?

Previously, the codebase used Literal string type annotations to define a set of valid string values for specific variables and function parameters. This approach, while functional, has several limitations that can be addressed by using Enum types:

**Improved Readability:**

Enums provide a clear, self-documenting way to represent a set of constant values. By using descriptive names for enum members, the code becomes more understandable and easier to read.

**Type Safety:**

Enums enforce type safety more rigorously than Literal strings. They ensure that only predefined values can be assigned, reducing the risk of runtime errors caused by invalid string literals.

**Enhanced Maintainability:**

Centralizing the definition of valid values in an Enum makes it easier to manage and update the set of possible values. Changes to the valid values need to be made in only one place, minimizing the risk of inconsistencies.

**Auto-Completion and IDE Support:**

Modern IDEs provide better support for enums, offering auto-completion and inline documentation, which can speed up development and reduce errors.

### How to test it?

Just install it and run any predefined template. Nothing should've changed. But I have not yet understood how the translation of width/height values into JS/HTML/CSS work !

### Example

Previously:

```py
    # [...]
    width: float | Literal["natural", "grow"] = "natural"
    height: float | Literal["natural", "grow"] = "natural"
```

Now:
```py
    # [...]
    width: float | ExpandStrategy = ExpandStrategy.NATURAL
    height: float | ExpandStrategy = ExpandStrategy.NATURAL
```
