### PR TITLE
Allow specifying additional files to watch

### DIFF
--- a/rio/cli/run_project/file_watcher_worker.py
+++ b/rio/cli/run_project/file_watcher_worker.py
@@ -56,4 +56,8 @@ class FileWatcherWorker:
         if path == self.proj.rio_toml_path:
             return True
 
+        # Reload is needed for files explicitly included in .rioignore
+        if self.proj.ignores.is_explicitly_included(path=path):
+            return True
+
         return False

--- a/rio/cli/run_project/file_watcher_worker.py
+++ b/rio/cli/run_project/file_watcher_worker.py
@@ -22,10 +22,8 @@ class FileWatcherWorker:
         """
         Watch the project directory for changes and report them as events.
         """
-        # Only care for certain files
-        filter = watchfiles.PythonFilter(
-            extra_extensions=".toml",
-        )
+        # Watch all files
+        filter = watchfiles.DefaultFilter()
 
         # Watch the project directory
         async for changes in watchfiles.awatch(


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/rio-labs/rio/blob/dev/CONTRIBUTING.md
-->

### What does it do?

I removed `watchfiles.PythonFilter` and modified the code to use `watchfiles.DefaultFilter` instead.

Additionally, I made changes to the `_file_triggers_reload` function to watch paths that are prefixed with "!" in the .rioignore file.

### Why is it needed?

This change is needed to improve the developer experience by enabling rio run to watch non-Python files, such as JSON and CSV files, in projects that utilize them.

### How to test it?

project directory 
```
.
├── .rioignore
├── my_project
│   ├── __init__.py
│   ├── assets
│   ├── components
│   └── pages
├── csv_data
│   └── user.csv
└── rio.toml
```

Configure the .rioignore file as follows:

```
!csv_data/user.csv
```

With this configuration, rio will automatically reload when changes are made to the user.csv file.


### Related issue(s)/PR(s)
FIx: issue #49
<!-- Let us know if this is related to any issue/pull request -->
