### PR TITLE
Fix Issue #123: Increase clickable area of Checkbox component

### DIFF
--- a/frontend/css/components/checkbox.scss
+++ b/frontend/css/components/checkbox.scss
@@ -14,10 +14,10 @@
     }
 
     position: absolute;
-    width: 1.4rem;
-    height: 1.4rem;
+    width: 3rem;
+    height: 3rem;
 
-    margin: 0;
+    margin: -0.8rem;
     padding: 0;
     border-width: 0;
 


### PR DESCRIPTION
### What does it do?

increase the clickable area for Checkbox components.

### Why is it needed?

Enhance usability and accessibility of the Checkbox component.

### How to test it?

Follow the documented instructions for setting up Rio, create a project with a Checkbox, and click within a 3rem x 3rem area around it to test the clickable area.

### Related issue(s)/PR(s)

Issue #123 
