### PR TITLE
Small fixes - type checking in debug mode and tree children

### DIFF
--- a/rio/components/tree_items.py
+++ b/rio/components/tree_items.py
@@ -62,7 +62,7 @@ class _TreeItemBase(Component):
     expand_button_open: Component
     expand_button_closed: Component
     expand_button_disabled: Component
-    children: list[SimpleTreeItem | CustomTreeItem] = []
+    children: list[Component] = []
     is_expanded: bool = False
     on_press: EventHandler[[]] = None
     on_expansion_change: EventHandler[TreeItemExpansionChangeEvent] = None
@@ -73,7 +73,7 @@ class _TreeItemBase(Component):
         is_expanded: bool = False,
         on_press: EventHandler[[]] = None,
         on_expansion_change: EventHandler[TreeItemExpansionChangeEvent] = None,
-        children: list[SimpleTreeItem | CustomTreeItem] | None = None,
+        children: list[Component] | None = None,
         expand_button_open: Component | None = None,
         expand_button_closed: Component | None = None,
         expand_button_disabled: Component | None = None,
@@ -210,7 +210,7 @@ class CustomTreeItem(_TreeItemBase, FundamentalComponent):
         is_expanded: bool = False,
         on_press: EventHandler[[]] = None,
         on_expansion_change: EventHandler[TreeItemExpansionChangeEvent] = None,
-        children: list[SimpleTreeItem | CustomTreeItem] | None = None,
+        children: list[Component] | None = None,
         expand_button_open: Component | None = None,
         expand_button_closed: Component | None = None,
         expand_button_disabled: Component | None = None,
@@ -380,7 +380,7 @@ class SimpleTreeItem(_TreeItemBase):
         secondary_text: str = "",
         left_child: Component | None = None,
         right_child: Component | None = None,
-        children: list[SimpleTreeItem | CustomTreeItem] | None = None,
+        children: list[Component] | None = None,
         is_expanded: bool = False,
         on_expansion_change: EventHandler[TreeItemExpansionChangeEvent] = None,
         on_press: EventHandler[[]] = None,

--- a/rio/components/tree_view.py
+++ b/rio/components/tree_view.py
@@ -4,7 +4,6 @@ import typing as t
 from ..utils import EventHandler
 from .component import Component, Key
 from .list_view import ListView, ListViewSelectionChangeEvent
-from .tree_items import _TreeItemBase
 
 __all__ = ["TreeView", "TreeViewSelectionChangeEvent"]
 
@@ -96,14 +95,14 @@ class TreeView(Component):
     `experimental`: True
     """
 
-    root_items: list[_TreeItemBase]
+    root_items: list[Component]
     selection_mode: t.Literal["none", "single", "multiple"] = "none"
     selected_items: list[Key] = []
     on_selection_change: EventHandler[TreeViewSelectionChangeEvent] = None
 
     def __init__(
         self,
-        *root_items: _TreeItemBase,
+        *root_items: Component,
         key: str | int | None = None,
         margin: float | None = None,
         margin_x: float | None = None,

--- a/rio/debug/monkeypatches.py
+++ b/rio/debug/monkeypatches.py
@@ -168,7 +168,11 @@ def LinearContainer_init(
     **kwargs,
 ) -> None:
     # Proportions related checks
-    if proportions is not None and not isinstance(proportions, str):
+    if (
+        proportions is not None
+        and not isinstance(proportions, str)
+        and not isinstance(proportions, PendingAttributeBinding)
+    ):
         proportions = list(proportions)
 
         # Make sure the number of proportions matches the number of children


### PR DESCRIPTION
1. allow pending attribute bindings when checking proportions in debug mode (in `monkeypatches.py`)
2. allow arbitrary components as children of tree items as any component's `build()` method may return the desired type