### PR TITLE
Style customization for edited text.

### DIFF
--- a/frontend/code/components/textInput.ts
+++ b/frontend/code/components/textInput.ts
@@ -1,3 +1,4 @@
+import { TextStyle } from "../dataModels";
 import { ComponentBase, DeltaState } from "./componentBase";
 import { Debouncer } from "../debouncer";
 import { InputBox, InputBoxStyle } from "../inputBox";
@@ -14,6 +15,7 @@ export type TextInputState = KeyboardFocusableComponentState & {
     label: string;
     accessibility_label: string;
     style: InputBoxStyle;
+    text_style: TextStyle;
     prefix_text: string;
     suffix_text: string;
     is_secret: boolean;
@@ -126,6 +128,13 @@ export class TextInputComponent extends KeyboardFocusableComponent<TextInputStat
 
         if (deltaState.style !== undefined) {
             this.inputBox.style = deltaState.style;
+        }
+
+        if (
+            deltaState.text_style !== undefined &&
+            deltaState.text_style !== null
+        ) {
+            this.inputBox.textStyle = deltaState.text_style;
         }
 
         if (deltaState.prefix_text !== undefined) {

--- a/frontend/code/inputBox.ts
+++ b/frontend/code/inputBox.ts
@@ -1,3 +1,5 @@
+import { TextStyle } from "./dataModels";
+import { applyTextStyleCss, textStyleToCss } from "./cssUtils";
 import { markEventAsHandled, stopPropagation } from "./eventHandling";
 
 export type InputBoxStyle = "underlined" | "rounded" | "pill";
@@ -303,6 +305,11 @@ export class InputBox {
         );
 
         this.outerElement.classList.add(`rio-input-box-style-${style}`);
+    }
+
+    set textStyle(style: TextStyle) {
+        let textStyleCss = textStyleToCss(style);
+        applyTextStyleCss(this._inputElement, textStyleCss);
     }
 
     get isSensitive(): boolean {

--- a/rio/components/text_input.py
+++ b/rio/components/text_input.py
@@ -132,6 +132,8 @@ class TextInput(KeyboardFocusableFundamentalComponent):
         seconds) before firing the `on_change` event. Use this to either make
         input very snappy, or save on processing overhead.
 
+    `text_style`: The style of the input. This can either be a `TextStyle` instance
+        to customize the default style, or `None` to keep the default unchanged.
 
     ## Examples
 

--- a/rio/components/text_input.py
+++ b/rio/components/text_input.py
@@ -190,6 +190,7 @@ class TextInput(KeyboardFocusableFundamentalComponent):
     is_sensitive: bool = True
     is_valid: bool = True
     change_delay: float = 0.8
+    text_style: rio.TextStyle | None = None
 
     on_change: rio.EventHandler[TextInputChangeEvent] = None
     on_confirm: rio.EventHandler[TextInputConfirmEvent] = None


### PR DESCRIPTION
Add `text_style` attribute to `TextInput` to allow style customization for edited text.