### PR TITLE
Automatic inclusion of front-end files during project build.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,11 +119,9 @@ artifacts = ["rio/frontend files/*"]
 [tool.hatch.build.targets.sdist]
 artifacts = ["rio/frontend files/*"]
 
-[[tool.hatch.build.targets.sdist.hooks.build-scripts.scripts]]
+[[tool.hatch.build.hooks.build-scripts.scripts]]
 commands = [
-    "uv sync",
-    "npm install",
-    "uv run python scripts/build.py",
+    "test -d .venv || (uv sync && npm install && uv run python scripts/build.py)",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ documentation = "https://rio.dev/docs"
 rio = "rio.__main__:main"
 
 [build-system]
-requires = ["hatchling==1.27.0"]
+requires = ["hatchling==1.27.0", "hatch-build-scripts", "uv"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
@@ -118,6 +118,13 @@ artifacts = ["rio/frontend files/*"]
 
 [tool.hatch.build.targets.sdist]
 artifacts = ["rio/frontend files/*"]
+
+[[tool.hatch.build.targets.sdist.hooks.build-scripts.scripts]]
+commands = [
+    "uv sync",
+    "npm install",
+    "uv run python scripts/build.py",
+]
 
 [tool.ruff]
 line-length = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,9 +119,13 @@ artifacts = ["rio/frontend files/*"]
 [tool.hatch.build.targets.sdist]
 artifacts = ["rio/frontend files/*"]
 
+[tool.hatch.build.hooks.build-scripts.env]
+PYTHONPATH = "."
+
 [[tool.hatch.build.hooks.build-scripts.scripts]]
 commands = [
-    "test -d .venv || (uv sync && npm install && uv run python scripts/build.py)",
+    "npm install",
+    "uvx --with-requirements pyproject.toml --verbose python -m scripts.build",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ PYTHONPATH = "."
 [[tool.hatch.build.hooks.build-scripts.scripts]]
 commands = [
     "npm install",
-    "uvx --with-requirements pyproject.toml --verbose python -m scripts.build",
+    "uvx --with-requirements pyproject.toml python -m scripts.build",
 ]
 
 [tool.ruff]


### PR DESCRIPTION

### What does it do?

Added build hooks to include front-end files automatically during project build.

### Why is it needed?

This enables rio installation directly from git, which is useful for quick iterations during development and testing.
`pip install git+https://github.com/ilya-pevzner/rio.git`

### How to test it?

I tested using the above command in a clean venv on Mac, Windows and Linux. 
