### PR TITLE
add platformdirs to deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "watchfiles>=0.21,<2.0",
     "yarl>=1.9,<2.0",
     "cssutils>=2.11.1,<3.0",
+    "platformdirs>=4.3.7",
 ]
 requires-python = ">= 3.10"
 readme = "README.md"


### PR DESCRIPTION

### What does it do?

Add the `platformdirs` package to `dependencies` in `pyproject.toml` 

### Why is it needed?

Without proper dependency, package won't install it `platformdirs` automatically, and it is required to e.g. import `app.py`

### How to test it?

Tested by running `pip install rio-ui@git+https://github.com/ilya-pevzner/rio.git@on-resize`

