### PR TITLE
feat: add radial gradient fill for text

### DIFF
--- a/rio/session.py
+++ b/rio/session.py
@@ -2913,7 +2913,7 @@ a.remove();
         return fill._serialize(self)
 
     def _host_and_get_fill_as_css_variables(
-        self, fill: fills._FillLike
+        self, fill: text_style._TextFill
     ) -> dict[str, str]:
         if isinstance(fill, rio.Color):
             return {
@@ -2933,16 +2933,10 @@ a.remove();
                 "backdrop-filter": "none",
             }
 
-        if isinstance(fill, rio.FrostedGlassFill):
-            return {
-                "color": f"#{fill.color.hexa}",
-                "background": "none",
-                "background-clip": "unset",
-                "fill-color": "unset",
-                "backdrop-filter": f"blur({fill.blur_size}rem)",
-            }
-
-        assert isinstance(fill, (rio.LinearGradientFill, rio.ImageFill)), fill
+        assert isinstance(
+            fill,
+            (rio.LinearGradientFill, rio.ImageFill, rio.RadialGradientFill),
+        ), fill
         return {
             "color": "var(--rio-local-text-color)",
             "background": fill._as_css_background(self),

--- a/rio/text_style.py
+++ b/rio/text_style.py
@@ -13,7 +13,12 @@ import rio
 from . import utils
 from .assets import Asset, HostedAsset, PathAsset
 from .color import Color
-from .fills import ImageFill, LinearGradientFill, SolidFill
+from .fills import (
+    ImageFill,
+    LinearGradientFill,
+    RadialGradientFill,
+    SolidFill,
+)
 from .self_serializing import SelfSerializing
 
 __all__ = [
@@ -26,7 +31,9 @@ __all__ = [
 logging.getLogger("CSSUTILS").setLevel(logging.CRITICAL)
 
 
-_TextFill = SolidFill | LinearGradientFill | ImageFill | Color
+_TextFill = (
+    SolidFill | LinearGradientFill | ImageFill | Color | RadialGradientFill
+)
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/rio-labs/rio/blob/main/CONTRIBUTING.md
-->

### What does it do?

This allows users to specify a Radial Gradient fill for text.

Besides, I corrected a type hint, and removed a code branch that would never be reached.

### Why is it needed?

For consistency: `LinearGradient` is already supported as text fill.

### How to test it?
I tested it with the following:

```python
import rio


@rio.page(url_segment="")
class RootComponent(rio.Component):
    def build(self) -> rio.Component:
        return rio.Text(
            "Welcome !",
            fill=rio.fills.RadialGradientFill(rio.Color.BLUE, rio.Color.CYAN),
            font_size=80,
        )


app = rio.App(
    build=RootComponent,
)
```

which yields:
<img width="225" height="100" alt="image" src="https://github.com/user-attachments/assets/3ad46f1d-5aa8-4619-aea6-4ea787d37e5a" />


### Related issue(s)/PR(s)

Related to https://github.com/rio-labs/rio/issues/171#issuecomment-3474937982
This could have been done as part of tackling https://github.com/rio-labs/rio/issues/172




cc @mad-moo, this is related to yesteday's discussion:
- In fact, gradient fills work for text.
- I tried to add the `FrostedGlassFill` too, but it doesn't seem to be working for texts.
- I fixed a type hint that was too broad (`FillLike`), while the variable is taking the fill from a `TextStyle` (so it's a `_TextFill`). Hence, it can not be a `FrostedGlassFill` and I deleted the associated branch.

-----
Please note that I could not apparently setup the unit tests correctly on my local machine. I followed the contribution guide, but still get a bunch of failure (on the main branch) when I run `uv run pytest` (and I suspect it's related to the `BrowserClient` :thinking: )
[EDIT]
I could run the tests involving `BrowserClient`, I just had to:
```sh
uv run playwright install --with-deps chromium
```
Maybe this can be added to the contributing guide ?
[EDIT2]
I still have some tests failing on main, e.g. `tests/test_events.py::test_unmount_and_remount`... Not sure if it's only on my local machine.
