### PR TITLE
fix(button): add fallback accessibility label for icon-only buttons

### DIFF
--- a/rio/components/button.py
+++ b/rio/components/button.py
@@ -187,6 +187,18 @@ class Button(Component):
                     align_x=0.5,
                 )
 
+        # --- BİZİM KATKIMIZ (Erişilebilirlik Düzenlemesi) ---
+        calculated_accessibility_label = self.accessibility_label
+        
+        if calculated_accessibility_label is None:
+            if isinstance(self.content, str) and self.content.strip():
+                calculated_accessibility_label = self.content
+            elif self.icon is not None:
+                # Sadece ikondan oluşan bir buton için ikon adını etiket yap
+                icon_name_parts = self.icon.split('/')[-1].split(':')
+                calculated_accessibility_label = f"{icon_name_parts[0].capitalize()} button"
+        # --------------------------------------------------
+
         # Delegate to a HTML Component
         return _ButtonInternal(
             on_press=self.on_press,
@@ -198,7 +210,7 @@ class Button(Component):
             is_loading=self.is_loading,
             min_width=8 if isinstance(self.content, str) else 0,
             min_height=2.2,
-            accessibility_label=self.accessibility_label,
+            accessibility_label=calculated_accessibility_label,
         )
 
     def __str__(self) -> str:
@@ -236,13 +248,7 @@ class _ButtonInternal(FundamentalComponent):
                 "style": "plain-text",
             }
 
-        accessibility_label = self.accessibility_label
-        if accessibility_label is None:
-            content = self.content
-            if isinstance(content, str):
-                accessibility_label = content
-
-        return {"accessibility_label": accessibility_label}
+        return {"accessibility_label": self.accessibility_label}
 
     async def _on_message_(self, msg: t.Any) -> None:
         # Parse the message


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/rio-labs/rio/blob/main/CONTRIBUTING.md
-->

### What does it do?

Modifies the `build` method in the `Button` component to dynamically generate a fallback `accessibility_label`. If the button is icon-only and no explicit accessibility label is provided, it parses the icon string (e.g., `material/settings` becomes `Settings button`).
### Why is it needed?

To address an accessibility (A11Y) issue. Previously, if a button was instantiated with an `icon` but no text `content`, the `accessibility_label` would default to `None`. This leaves screen readers without appropriate context for icon-only buttons, degrading the user experience for visually impaired users.

### How to test it?
Tested locally by rendering an icon-only button (`rio.Button(icon="material/settings")`) and verifying the JSON serialization output and HTML rendering for the correct `accessibility_label`.

### Related issue(s)/PR(s)
None.
